### PR TITLE
Domain expired

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-nofuture.in


### PR DESCRIPTION
Removed CNAME as the domain has expired and the page should still be accessable.